### PR TITLE
Fix use after free in lab06 and lab07

### DIFF
--- a/lab06/addIntToStartOfListTest.cpp
+++ b/lab06/addIntToStartOfListTest.cpp
@@ -30,6 +30,8 @@ int main() {
 		linkedListToString(emptyList),
 		"linkedListToString(emptyList)");
 
+  list = emptyList;
+
   addIntToStartOfList(list,7);
 
   assertEquals( "[7]->null", 

--- a/lab07/addIntToEndOfListTest.cpp
+++ b/lab07/addIntToEndOfListTest.cpp
@@ -33,6 +33,8 @@ int main() {
   int empty[0]={};
   LinkedList *emptyList = arrayToLinkedList(empty,0);
 
+  list = emptyList;
+
   assertTrue(list->head == NULL,"list->head->data == NULL");
   assertTrue(list->tail == NULL,"list->tail->data == NULL)");
   assertEquals( "null", 


### PR DESCRIPTION
lab06 and lab07 both have a bug in `addIntToEndOfListTest.cpp` where `list` is used after freeing it. I've assigned it to an empty list to fix this.